### PR TITLE
Fix windows templates path

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ This is not meant to depend on any fat frameworks, especially web frameworks, al
   ```bash
   go get -u -v ./...
  
-  go run cmd/askme/main.go
+  go run main.go
   ```
 * (Optional) if you prefer Docker, run the following commands
   ```bash
   docker build -t go-askme .
 
-  docker run --env-file=cmd/askme/.env --rm -p 8080:8080 go-askme
+  docker run --env-file=.env --rm -p 8080:8080 go-askme
   ```
 Then from a browser window, navigate to http://localhost:8080

--- a/web/framework/render.go
+++ b/web/framework/render.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	pattern      = "^templates\\/.+\\.gohtml$"
+	pattern      = `^templates(\\|\/)\w+\.gohtml$` // matches templates/*.gohtml (Linux & macOS) or templates\*.gohtml (Windows)
 	templateName = "master"
 )
 


### PR DESCRIPTION
The Regex was only working for Linux/macOS file paths, this change
allows windows paths as well.

And a minor README fix for the docker commands